### PR TITLE
Override close method to make sure all messages get sent

### DIFF
--- a/lib/logstash/outputs/stomp.rb
+++ b/lib/logstash/outputs/stomp.rb
@@ -68,10 +68,10 @@ class LogStash::Outputs::Stomp < LogStash::Outputs::Base
   end # def register
 
   public
-  def do_close
+  def close
     @logger.warn("Disconnecting from stomp broker")
     @client.disconnect if @client.connected?
-  end # def do_close
+  end # def close
 
   def multi_receive(events)
 


### PR DESCRIPTION
This PR fixes #8 by making sure that the stomp client properly disconnects from the stomp broker and gets a chance to empty his buffers. More information on why this is needed is available [here](https://github.com/iande/onstomp/blob/master/extra_doc/UserNarrative.md#what-really-goes-down-when-you-disconnect)

it is worth noting that this PR also includes changes made in PR #4 to add support for headers.