### PR TITLE
With the move to the Java logger the new methods doesn't accept an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.4
+  - A `logger.debug` statement was crashing because of a type mismatch
+
+## 3.0.3
+  - Correctly merges the headers before sending the events and fix an undefined `event` variables #13, #14
+
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/outputs/stomp.rb
+++ b/lib/logstash/outputs/stomp.rb
@@ -72,7 +72,7 @@ class LogStash::Outputs::Stomp < LogStash::Outputs::Base
 
   def multi_receive(events)
 
-    @logger.debug(["stomp sending events in batch", { :host => @host, :events => events.length }])
+    @logger.debug("stomp sending events in batch", { :host => @host, :events => events.length })
 
     @client.transaction do |t|
       events.each { |event|

--- a/logstash-output-stomp.gemspec
+++ b/logstash-output-stomp.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-stomp'
-  s.version         = '3.0.2'
+  s.version         = '3.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send events to a stomp server"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Ruby didn't care about the argument type and was just serializing everything to the log.
